### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Run everything each day around 4:30 - right after the data has been released.
 30 16 * * * cd path/to/federal-treasury-api && ./run.sh
 ```
 
-####Optional: set up logging
+#### Optional: set up logging
 ```
 30 16 * * * cd path/to/federal-treasury-api && ./run.sh >> run.log 2>> err.log
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
